### PR TITLE
Fix code scanning alert no. 1: Implicitly exported Android component

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,8 @@
 
         <activity
             android:name=".Activities.ActivityRegisterPhoneNumber"
-            android:windowSoftInputMode="stateAlwaysHidden">
+            android:windowSoftInputMode="stateAlwaysHidden"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 


### PR DESCRIPTION
Fixes [https://github.com/gouthamansenthil/Wanderlust-The-Travellers-App-master/security/code-scanning/1](https://github.com/gouthamansenthil/Wanderlust-The-Travellers-App-master/security/code-scanning/1)

To fix the problem, we need to explicitly set the `android:exported` attribute for the `ActivityRegisterPhoneNumber` component. This will ensure that the component is not implicitly exported and will prevent unintended access. The best way to fix this without changing existing functionality is to add `android:exported="false"` to the activity declaration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
